### PR TITLE
fix: handle Mistral JSON parsing error

### DIFF
--- a/lib/error_notifier.rb
+++ b/lib/error_notifier.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Notifies Sentry of errors
+class ErrorNotifier
+  def self.notify(error)
+    Sentry.capture_exception(error)
+  end
+end

--- a/lib/llms/mistral.rb
+++ b/lib/llms/mistral.rb
@@ -49,7 +49,11 @@ module Llms
       @result = JSON.parse(response.body)
       content = result.dig("choices", 0, "message", "content")
       content_json_result = content[/(\{.+\})/im, 1]
-      @read_attributes = JSON.parse(content_json_result, symbolize_names: true)
+      @read_attributes = begin
+        JSON.parse(content_json_result, symbolize_names: true)
+      rescue JSON::ParserError
+        raise ResultError, "Parsing JSON inside content: #{content_json_result}"
+      end
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize

--- a/lib/quote_reader/global.rb
+++ b/lib/quote_reader/global.rb
@@ -36,7 +36,7 @@ module QuoteReader
       @anonymised_text = Anonymiser.new(text).anonymised_text
 
       qa_reader = Qa.new(anonymised_text)
-      @qa_attributes = qa_reader.read
+      @qa_attributes = qa_reader.read || {}
       @qa_result = qa_reader.result
       @qa_version = qa_reader.version
 

--- a/lib/quote_reader/qa.rb
+++ b/lib/quote_reader/qa.rb
@@ -20,15 +20,17 @@ module QuoteReader
     private
 
     def llm_read_attributes
-      if Llms::Mistral.configured?
-        mistral = Llms::Mistral.new(prompt)
-        mistral.chat_completion(text)
+      return unless Llms::Mistral.configured?
 
-        @read_attributes = mistral.read_attributes
-        @result = mistral.result
+      mistral = Llms::Mistral.new(prompt)
+      begin
+        mistral.chat_completion(text)
+      rescue ResultError => e
+        ErrorNotifier.notify(e)
       end
 
-      read_attributes || {}
+      @read_attributes = mistral.read_attributes
+      @result = mistral.result
     end
 
     def prompt


### PR DESCRIPTION
Logguer l'erreur mais retourner un résultat vide pour l'usager.