### PR TITLE
fix: CI warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,7 +95,7 @@ jobs:
             --network="host" \
             -e DATABASE_URL="${{ env.DATABASE_URL }}" \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            --rm rails-template bundle exec rspec
+            --rm rails-template bash -c "bin/rails db:environment:set RAILS_ENV=test && bundle exec rspec"
   integration-tests:
     name: "Integration tests: Cucumber"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoiding error:

```
+ exec bundle exec rspec
bin/rails aborted!
ActiveRecord::EnvironmentMismatchError: You are attempting to modify a database that was last run in `development` environment. (ActiveRecord::EnvironmentMismatchError)
You are running in `test` environment. If you are sure you want to continue, first set the environment using:

        bin/rails db:environment:set RAILS_ENV=test


Tasks: TOP => db:test:load_schema => db:test:purge => db:check_protected_environments
(See full trace by running task with --trace)
```