### PR TITLE
feat: add QuotesCase coherence error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem "sib-api-v3-sdk", require: false # Brevo (ex Sendinblue) API
 gem "strip_attributes"
 
 # Quote files Reading
+gem "fuzzy-string-match", require: false
 gem "mime-types", require: false
 gem "mini_magick", require: false
 gem "pdf-reader", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
+    RubyInline (3.14.2)
+      ZenTest (~> 4.3)
+    ZenTest (4.12.2)
     actioncable (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
@@ -287,6 +290,8 @@ GEM
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
+    fuzzy-string-match (1.0.1)
+      RubyInline (>= 3.8.6)
     globalid (1.2.1)
       activesupport (>= 6.1)
     good_job (4.10.2)
@@ -808,6 +813,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
+  fuzzy-string-match
   good_job
   guard
   guard-cucumber
@@ -865,6 +871,8 @@ DEPENDENCIES
 
 CHECKSUMS
   Ascii85 (2.0.1) sha256=15cb5d941808543cbb9e7e6aea3c8ec3877f154c3461e8b3673e97f7ecedbe5a
+  RubyInline (3.14.2) sha256=211cbec89f1961a4bc8d49f75540546c19942984b218d7d0c66575a82c54da10
+  ZenTest (4.12.2) sha256=814e7478a28f631df8f802aee40bd1faa2a53df1fb50e086eb8655f9ee5d60b9
   actioncable (8.0.2) sha256=7bcce2df62e91a80143592600e16583c273e98aab50ae40a9f6a2604bb3289a0
   actionmailbox (8.0.2) sha256=3d8fb3453913e6257da4d02004bbfa2b997dfd10672f8d990e95013983e2cedb
   actionmailer (8.0.2) sha256=b0c968b38576ec56a3dc2795931818e0aaae6a18cc9801f53f175c12d4b277d0
@@ -964,6 +972,7 @@ CHECKSUMS
   formtastic (5.0.0) sha256=71cc99c8227208f64da8d2b0926d97cef1e5f77e0105047cd57fddeccd3a6416
   formtastic_i18n (0.7.0) sha256=ecef51c9e9030c00f19e69d2483b77f4515c9587d74268b76cf4b6e7988c8e78
   fugit (1.11.1) sha256=e89485e7be22226d8e9c6da411664d0660284b4b1c08cacb540f505907869868
+  fuzzy-string-match (1.0.1) sha256=0740e515b3d1f7a40bd7f058a67a63682a9f4d98e4a95a9eb670aa562a047549
   globalid (1.2.1) sha256=70bf76711871f843dbba72beb8613229a49429d1866828476f9c9d6ccc327ce9
   good_job (4.10.2) sha256=df4f1c29f6d82dd7199ebf351b30755978852235e4c64d777edf714b095126ff
   guard (2.19.1) sha256=b8bc52694be3d8b26730280de7dcec7fe92ea1cff3414246fe96af3f23580f3d

--- a/README.md
+++ b/README.md
@@ -180,12 +180,12 @@ sequenceDiagram
 
     QuoteCheckCheckJob<<->>Mistral LLM: Extraction des données gestes et caractéristiques du texte anonymisé
 
-    QuoteCheckCheckJob->>QuoteCheckCheckJob: Validation des données selon algorithme Ruby maison et ajout d'erreurs
+    QuoteCheckCheckJob->>QuoteCheckCheckJob: Validation des données selon algorithme Ruby maison et ajout d'erreurs, dont vérification cohérence avec données externes (SIRENE, ADEME)
 
     QuoteCheckCheckJob->>Backend: retours avec données et erreurs
     deactivate QuoteCheckCheckJob
 
-    Backend->>Frontend: Retour API et affichage du résultat
+    Backend->>Frontend: Retour API QuotesCase et/ou QuoteCheck(s) avec erreurs cohérence dossier à la volée et affichage du résultat
 ```
 
 Nous suivons les recommendations et les conventions du framework Ruby on Rails et de la communauté.

--- a/app/admin/quotes_cases.rb
+++ b/app/admin/quotes_cases.rb
@@ -49,9 +49,9 @@ ActiveAdmin.register QuotesCase do # rubocop:disable Metrics/BlockLength
 
           row :status
 
-          row :quote_checks do |quote_case|
+          row :quote_checks do |quotes_case|
             content_tag(:ul) do
-              quote_case.quote_checks.default_order.map do |quote_check|
+              quotes_case.quote_checks.default_order.map do |quote_check|
                 content_tag(:li, link_to(
                                    quote_check.file.filename,
                                    admin_quote_check_path(quote_check),
@@ -69,6 +69,12 @@ ActiveAdmin.register QuotesCase do # rubocop:disable Metrics/BlockLength
     end
 
     tabs do
+      tab "Retour API avec erreurs incohérence pour frontend" do
+        pre JSON.pretty_generate(
+          QuotesCaseSerializer.new(resource).as_json
+        )
+      end
+
       instance_exec(&processing_logs_tab(resource))
     end
   end

--- a/app/models/concerns/quotes_case_post_check_metadata.rb
+++ b/app/models/concerns/quotes_case_post_check_metadata.rb
@@ -26,7 +26,7 @@ module QuotesCasePostCheckMetadata
   end
 
   # valid? is already used by the framework
-  def quote_case_valid?
+  def quotes_case_valid?
     status == "valid"
   end
 

--- a/app/models/concerns/quotes_case_validation.rb
+++ b/app/models/concerns/quotes_case_validation.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Add QuotesCase validation
+module QuotesCaseValidation
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :validation_control_codes, :validation_controls_count,
+                  :validation_errors, :validation_error_details,
+                  :validation_version
+  end
+
+  # Validates the QuotesCase attributes
+  # and sets the validation virtual attributes.
+  def custom_validate! # rubocop:disable Metrics/MethodLength
+    @validation_control_codes = 0
+    @validation_controls_count = 0
+
+    @validation_errors = []
+    @validation_error_details = []
+
+    validator = QuotesCaseValidator.new(
+      attributes.merge("quote_checks" => quote_checks.map(&:attributes)),
+      quotes_case_id: id
+    )
+    validator.validate!
+
+    # TODO: Record in database
+    # quotes_case.assign_attributes(
+    #   validation_control_codes: validator.control_codes,
+    #   validation_controls_count: validator.controls_count,
+    #   validation_errors: validator.errors,
+    #   validation_error_details: validator.error_details,
+    #   validation_version: validator.version
+    # )
+    @validation_control_codes = validator.control_codes
+    @validation_controls_count = validator.controls_count
+    @validation_errors = validator.errors
+    @validation_error_details = validator.error_details
+    @validation_version = validator.version
+  end
+end

--- a/app/models/quotes_case.rb
+++ b/app/models/quotes_case.rb
@@ -6,6 +6,7 @@ class QuotesCase < ApplicationRecord
   include QuoteInputMetadata
   include QuotesCaseBackoffice
   include QuotesCasePostCheckMetadata
+  include QuotesCaseValidation
 
   has_many :quote_checks, inverse_of: :case, dependent: :destroy
 end

--- a/app/serializers/object_with_validation_serializer.rb
+++ b/app/serializers/object_with_validation_serializer.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class ObjectWithValidationSerializer < BaseSerializer
+  def control_codes
+    object.validation_control_codes
+  end
+
+  def controls_count
+    object.validation_controls_count
+  end
+
+  def errors
+    validation_errors
+  end
+
+  def error_details
+    validation_error_details&.map do
+      it.merge(
+        "comment" => sanitize(object.validation_error_edits&.dig(it["id"], "comment")),
+        "deleted" => object.validation_error_edits&.dig(it["id"], "deleted") || false
+      ).compact
+    end
+  end
+
+  def error_messages
+    validation_errors&.index_with do
+      I18n.t("quote_validator.errors.#{it}")
+    end
+  end
+
+  def validation_errors
+    validation_error_details&.map { it.fetch("code") }
+  end
+
+  def validation_error_details
+    @validation_error_details ||= object.validation_error_details&.map do |it|
+      it.transform_keys(&:to_s)
+    end
+  end
+end

--- a/app/serializers/quotes_case_serializer.rb
+++ b/app/serializers/quotes_case_serializer.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
-class QuotesCaseSerializer < BaseSerializer
-  attributes :id, :reference, :status
+class QuotesCaseSerializer < ObjectWithValidationSerializer
+  attributes :id, :reference,
+             :status,
+             :started_at, :finished_at,
+             # Virtual attributes
+             :errors, :error_details, :error_messages,
+             :control_codes, :controls_count
+
   has_many :quote_checks, serializer: QuoteCheckInsideCaseSerializer, if: :quote_checks
 
   def quote_checks

--- a/config/locales/fr/mon-devis-sans-oublis-quote-validator.yml
+++ b/config/locales/fr/mon-devis-sans-oublis-quote-validator.yml
@@ -2,6 +2,7 @@ fr:
   quote_validator:
     error_categories:
       admin: "Mentions administratives"
+      case_incoherence: "Incohérence des documents du dossier"
       file: "Fichier"
       gestes: "Descriptif technique des gestes"
       server: "Serveur"
@@ -26,7 +27,7 @@ fr:
       numero_devis_manquant_infos: "Un devis doit avoir un numéro unique permettant un suivi plus précis."
       date_validite_manquant: "Attention, si la date de validité n'est pas indiquée, elle est de 3 mois par défaut"
       date_devis_manquant: "La date d'édition du devis est manquante"
-      date_chantier_manquant: "La date prévue de début de chantier n'est pas présente, elle est cependant recommandée" 
+      date_chantier_manquant: "La date prévue de début de chantier n'est pas présente, elle est cependant recommandée"
       date_pre_visite_manquant: "La date de pré visite technique est fortement recommandée, notamment dans le cadre des CEE"
 
       # Informations de l'artisan
@@ -52,12 +53,12 @@ fr:
       pro_assurance_manquant_infos: "Assurance professionnelle souscrite avec le N° de la police d'assurance, le type (décennale, biennale ...), les coordonnées de l'assureur ou du garant et la couverture géographique du contrat ou de la garantie."
 
       # Information du client : 
-      client_prenom_manquant: "Le prénom du client est manquant" 
+      client_prenom_manquant: "Le prénom du client est manquant"
       client_prenom_manquant_infos: "Mise en garde : le devis doit être établi au nom et prénom de la personne ayant fait la demande d’aide."
       client_nom_manquant: "Le nom du client est manquant"
       client_nom_manquant_infos: "Mise en garde : le devis doit être établi au nom et prénom de la personne ayant fait la demande d’aide."
       client_civilite_manquant: "La civilité du client est manquante"
-      client_adresse_manquant: "L'adresse du client est manquante" 
+      client_adresse_manquant: "L'adresse du client est manquante"
       chantier_adresse_manquant: "Si l'adresse du chantier est différente de l'adresse de facturation, il faut l'indiquer clairement."
       chantier_facturation_idem: "L'adresse de réalisation des travaux n'est pas indiquée. Est-ce bien la même que l'adresse de facturation ?"
 
@@ -107,7 +108,7 @@ fr:
       chaudiere_reference_regulateur_manquant: "Le modèle du régulateur installé n'est pas indiqué"
       chaudiere_classe_regulateur_manquant: "Le régulateur doit être de classe IV et cela doit être indiqué"
       # validate_poele_insert
-      poele_type_combustible_manquant: "Le combustible utilisé par le poêle ou l'insert n'est pas indiqué" 
+      poele_type_combustible_manquant: "Le combustible utilisé par le poêle ou l'insert n'est pas indiqué"
       poele_type_combustible_manquant_infos: "Le combustible peut être le bois, les bûches ou les granulés."
       poele_rendement_energetique_manquant: "Le rendement énergétique du poêle ou de l'insert est manquant"
       poele_rendement_energetique_manquant_infos: "Le rendement est une valeur en pourcentage."
@@ -167,7 +168,7 @@ fr:
       # validate_chauffe_eau_thermodynamique
       chauffe_eau_thermodynamique_cop_manquant: "Le coefficient de performance de l'équipement n'est pas indiqué"
       chauffe_eau_thermodynamique_cop_manquant_infos: "Le COP doit être mesuré conformément aux condition de la norme EN 16147."
-      chauffe_eau_thermodynamique_type_installation_manquant: "Le type d'installation du chauffe-eau thermodynamique n'est pas indiqué" 
+      chauffe_eau_thermodynamique_type_installation_manquant: "Le type d'installation du chauffe-eau thermodynamique n'est pas indiqué"
       chauffe_eau_thermodynamique_type_installation_manquant_infos: " Le chauffe-eau thermodynamique est-il sur air extérieur, sur air extrait ou sur air ambiant?" # air exterieur, sur air exrait ou sur air ambiant
 
 
@@ -181,10 +182,10 @@ fr:
       isolation_surface_manquant: "La surface isolée n'est pas indiquée"
       isolation_epaisseur_manquant: "L'épaisseur de l'isolant est manquante"
       isolation_epaisseur_manquant_infos: "L'épaisseur totale de l'isolant doit être précisée en cm."
-      isolation_r_manquant: "La résistance thermique de l'installation n'est pas indiquée" 
+      isolation_r_manquant: "La résistance thermique de l'installation n'est pas indiquée"
       isolation_r_manquant_infos: "La résistance thermique (R) de l'installation doit être précisée et est définie en m2.K/W." # Decimal (m².K/W)
       # validate_isolation_toiture_terrasse
-      isolation_type_isolation_toiture_terrasse_manquant: "Le type de l'isolation de la toiture-terrasse est manquant" 
+      isolation_type_isolation_toiture_terrasse_manquant: "Le type de l'isolation de la toiture-terrasse est manquant"
       isolation_type_isolation_toiture_terrasse_manquant_infos: "L'isolation est-elle faite par l'intérieur ou par l'extérieur ?"
       # validate_isolation_plancher_bas
       isolation_localisation_plancher_bas_manquant: "L'emplacement de l'isolation des planchers bas n'est pas indiqué"
@@ -256,3 +257,13 @@ fr:
       vmc_double_flux_emplacement_bouches_soufflage_manquant: "L'emplacement des bouches de soufflages n'est pas précisé"
       vmc_double_flux_emplacement_bouches_soufflage_manquant_infos: "Attention de vérifier l'absence d'entrées d'air sur toutes les menuiseries."
       vmc_double_flux_nombre_bouches_soufflage_manquant: "Le nombre de bouches de soufflage n'est pas précisé"
+
+
+#################################################
+####         QUOTES CASE COHERENCE           ####
+#################################################
+
+
+      client_prenom_incoherent: "Le prénom du client est différent dans les documents"
+      client_nom_incoherent: "Le nom du client est différent dans les documents"
+      client_adresse_incoherent: "L'adresse du client est différent dans les documentse"

--- a/db/migrate/20250616213352_remove_quote_checks_string_on_quotes_cases.rb
+++ b/db/migrate/20250616213352_remove_quote_checks_string_on_quotes_cases.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveQuoteChecksStringOnQuotesCases < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :quotes_cases, :quote_checks, :string, default: "mdso"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_10_165954) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_16_213352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -222,7 +222,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_165954) do
   end
 
   create_table "quotes_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "quote_checks", default: "mdso"
     t.string "source_name", default: "mdso"
     t.string "reference"
     t.datetime "created_at", null: false
@@ -230,7 +229,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_165954) do
     t.string "renovation_type", default: "ampleur", null: false
     t.jsonb "metadata"
     t.string "profile", default: "conseiller", null: false
-    t.index ["quote_checks"], name: "index_quotes_cases_on_quote_checks"
     t.index ["reference"], name: "index_quotes_cases_on_reference"
     t.index ["renovation_type"], name: "index_quotes_cases_on_renovation_type"
     t.index ["source_name"], name: "index_quotes_cases_on_source_name"

--- a/lib/quote_validator/quotes_case.rb
+++ b/lib/quote_validator/quotes_case.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'fuzzystringmatch' # rubocop:disable Style/StringLiterals
+
+module QuoteValidator
+  # Validator for the QuotesCase
+  class QuotesCase < Base
+    VERSION = "0.0.1"
+
+    def validate!
+      super do
+        validate_quote_checks_coherence if quotes_case[:quote_checks] && quotes_case[:quote_checks].size > 1
+      end
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def validate_quote_checks_coherence # rubocop:disable Metrics/MethodLength
+      add_error_if(
+        "client_prenom_incoherent",
+        arrays_intersect(quotes_case[:quote_checks].map do
+          Array.wrap(it.dig(:read_attributes, :client_prenoms))
+        end).empty?
+      )
+      add_error_if(
+        "client_nom_incoherent",
+        arrays_intersect(quotes_case[:quote_checks].map do
+          Array.wrap(it.dig(:read_attributes, :client_noms_de_famille))
+        end).empty?
+      )
+      add_error_if(
+        "client_adresse_incoherent",
+        arrays_intersect(quotes_case[:quote_checks].map do
+          Array.wrap(it.dig(:read_attributes, :client_adresses))
+        end).empty?
+      )
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def add_error_if(code, condition, category: "case_incoherence", type: "error")
+      super(code, condition,
+                type:,
+                category:)
+    end
+
+    private
+
+    def arrays_intersect(arrays, threshold: 0.90)
+      jarow = FuzzyStringMatch::JaroWinkler.create(:pure) # Ruby version
+      arrays.reduce do |common, current|
+        common.select do |item_a|
+          current.any? { |item_b| jarow.getDistance(item_a, item_b) > threshold }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/quote_validator/global_spec.rb
+++ b/spec/lib/quote_validator/global_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe QuoteValidator::Global, type: :service do
-  subject(:validator) { described_class.new(quote_attributes) }
+  subject(:validator) { described_class.new(attributes) }
 
-  let(:quote_attributes) do
+  let(:attributes) do
     {}
   end
 
@@ -47,7 +47,7 @@ RSpec.describe QuoteValidator::Global, type: :service do
     end
 
     context "with symbolized and stringified keys" do
-      let(:quote_attributes) do
+      let(:attributes) do
         {
           client: {
             nom: "DOE",

--- a/spec/lib/quote_validator/quotes_case_spec.rb
+++ b/spec/lib/quote_validator/quotes_case_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QuoteValidator::QuotesCase, type: :service do
+  subject(:validator) { described_class.new(attributes, quotes_case_id: quotes_case.id) }
+
+  let(:quotes_case) do
+    create(:quotes_case).tap do |quotes_case|
+      create_list(:quote_check, 2, case: quotes_case)
+    end
+  end
+
+  let(:attributes) do
+    quotes_case.attributes.merge(
+      "quote_checks" => quotes_case.quote_checks.map(&:attributes)
+    )
+  end
+
+  describe "#control_codes" do
+    before { validator.validate! }
+
+    it "returns control_codes" do
+      expect(validator.control_codes).to include("client_prenom_incoherent", "client_nom_incoherent")
+    end
+  end
+
+  describe "#controls_count" do
+    before { validator.validate! }
+
+    it "returns controls_count" do
+      expect(validator.controls_count).to eq(3)
+    end
+  end
+
+  describe "#errors" do
+    before { validator.validate! }
+
+    it "returns errors" do
+      expect(validator.errors).to include("client_prenom_incoherent")
+    end
+  end
+
+  describe "#error_details" do
+    before { validator.validate! }
+
+    it "returns error_details" do
+      expect(validator.error_details.dig(0, :code)).to eq("client_prenom_incoherent")
+    end
+  end
+
+  describe "#validate!" do
+    it "returns validation" do
+      expect(validator.validate!).to be false
+    end
+
+    context "with symbolized and stringified keys" do
+      let(:quotes_case) do
+        create(:quotes_case).tap do |quotes_case|
+          create(:quote_check, case: quotes_case, read_attributes: { client_noms_de_famille: %w[Andrea Baptiste] })
+          create(:quote_check, case: quotes_case, read_attributes: { client_noms_de_famille: %w[Baptise Chloé] })
+        end
+      end
+
+      before { validator.validate! }
+
+      it "stores errors" do
+        expect(validator.errors).not_to include(
+          "client_nom_incoherent"
+        )
+      end
+
+      it "stores control codes" do
+        expect(validator.control_codes).to include(
+          "client_prenom_incoherent",
+          "client_adresse_incoherent"
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/quote_validator/works/chauffage_spec.rb
+++ b/spec/lib/quote_validator/works/chauffage_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe QuoteValidator::Works::Chauffage, type: :service do
-  subject(:validator) { described_class.new(quote_attributes) }
+  subject(:validator) { described_class.new(attributes) }
 
-  let(:quote_attributes) do
+  let(:attributes) do
     {}
   end
 

--- a/spec/requests/api/v1/quote_checks_spec.rb
+++ b/spec/requests/api/v1/quote_checks_spec.rb
@@ -60,17 +60,17 @@ RSpec.describe "/api/v1/quote_checks" do
     end
 
     context "with case_id" do
-      let(:quote_case) { create(:quotes_case) }
+      let(:quotes_case) { create(:quotes_case) }
       let(:quote_check_params) do
         {
           file: file,
           profile: "artisan",
-          case_id: quote_case.id
+          case_id: quotes_case.id
         }
       end
 
       it "reuses the renovation_type from case" do
-        expect(QuoteCheck.find(json.fetch("id")).renovation_type).to eq(quote_case.renovation_type)
+        expect(QuoteCheck.find(json.fetch("id")).renovation_type).to eq(quotes_case.renovation_type)
       end
     end
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -562,6 +562,9 @@ RSpec.configure do |config|
               },
               nullable: true
             },
+            started_at: {
+              type: :datetime
+            },
             finished_at: {
               type: :datetime,
               nullable: true
@@ -635,6 +638,44 @@ RSpec.configure do |config|
               type: :array,
               items: { "$ref" => "#/components/schemas/quote_check" },
               description: "liste des analyses de devis (QuoteChecks) dans ce dossier",
+              nullable: true
+            },
+            control_codes: {
+              type: :array,
+              items: { "$ref" => "#/components/schemas/quote_check_error_code" },
+              description: "liste des codes des points contrôlés",
+              nullable: true
+            },
+            controls_count: {
+              type: :integer,
+              description: "nombre de points contrôlés",
+              nullable: true
+            },
+            errors: {
+              type: :array,
+              items: { "$ref" => "#/components/schemas/quote_check_error_code" },
+              description: "liste des erreurs dans ordre à afficher",
+              nullable: true
+            },
+            error_details: {
+              type: :array,
+              items: { "$ref" => "#/components/schemas/quote_check_error_details" },
+              description: "liste des erreurs avec détails dans ordre à afficher",
+              nullable: true
+            },
+            error_messages: {
+              type: :object,
+              additionalProperties: {
+                type: :string,
+                description: "code d'erreur => message"
+              },
+              nullable: true
+            },
+            started_at: {
+              type: :datetime
+            },
+            finished_at: {
+              type: :datetime,
               nullable: true
             }
           },

--- a/swagger/v1/mon-devis-sans-oublis_api_v1_internal_swagger.yaml
+++ b/swagger/v1/mon-devis-sans-oublis_api_v1_internal_swagger.yaml
@@ -265,7 +265,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://www.datatourisme.fr/ontology/core/1.0/#siret
-          x-cardinality: 63252
+          x-cardinality: 63250
           x-capabilities:
             textAgg: true
           x-concept:
@@ -277,7 +277,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://www.w3.org/2000/01/rdf-schema#label
-          x-cardinality: 62619
+          x-cardinality: 62574
           x-capabilities:
             textAgg: true
           x-concept:
@@ -289,7 +289,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://schema.org/address
-          x-cardinality: 63474
+          x-cardinality: 63455
           x-capabilities:
             textAgg: true
           x-concept:
@@ -313,7 +313,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://schema.org/City
-          x-cardinality: 19541
+          x-cardinality: 19531
           x-capabilities:
             textAgg: true
           x-concept:
@@ -345,7 +345,7 @@ components:
           type: string
           description: ''
           x-refersTo: https://www.w3.org/2006/vcard/ns#tel
-          x-cardinality: 59534
+          x-cardinality: 59543
           x-capabilities:
             textAgg: true
           x-concept:
@@ -357,7 +357,7 @@ components:
           type: string
           description: ''
           x-refersTo: https://www.w3.org/2006/vcard/ns#email
-          x-cardinality: 61513
+          x-cardinality: 61591
           x-capabilities:
             textAgg: true
           x-concept:
@@ -369,7 +369,7 @@ components:
           type: string
           description: ''
           x-refersTo: https://schema.org/WebPage
-          x-cardinality: 37557
+          x-cardinality: 37598
           x-capabilities:
             textAgg: true
           x-concept:
@@ -380,14 +380,14 @@ components:
           title: Code qualification
           type: string
           description: ''
-          x-cardinality: 465
+          x-cardinality: 464
           x-capabilities:
             textAgg: true
         nom_qualification:
           title: Nom de la qualification
           type: string
           description: ''
-          x-cardinality: 473
+          x-cardinality: 472
           x-capabilities:
             textAgg: true
         url_qualification:
@@ -395,7 +395,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://schema.org/DigitalDocument
-          x-cardinality: 75488
+          x-cardinality: 75492
           x-capabilities: {}
           x-concept:
             id: attachment
@@ -543,7 +543,7 @@ components:
           description: Cette date correspond à la date de début de qualification transmise
             par l'organisme de qualification
           x-capabilities: {}
-          x-cardinality: 1867
+          x-cardinality: 1869
         lien_date_fin:
           title: Date de fin de qualification
           type: string
@@ -551,7 +551,7 @@ components:
           description: Cette date correspond à la date de fin de qualification transmise
             par l'organisme de qualification
           x-capabilities: {}
-          x-cardinality: 1549
+          x-cardinality: 1551
         _file.content:
           x-calculated: true
           type: string
@@ -694,11 +694,13 @@ components:
       type: string
       enum:
       - admin
+      - case_incoherence
       - file
       - gestes
       - server
-      description: 'admin: Mentions administratives | file: Fichier | gestes: Descriptif
-        technique des gestes | server: Serveur'
+      description: 'admin: Mentions administratives | case_incoherence: Incohérence
+        des documents du dossier | file: Fichier | gestes: Descriptif technique des
+        gestes | server: Serveur'
     quote_check_error_code:
       type: string
       description: code d'erreur de validation
@@ -1085,6 +1087,8 @@ components:
             type: string
             description: code d'erreur => message
           nullable: true
+        started_at:
+          type: datetime
         finished_at:
           type: datetime
           nullable: true
@@ -1158,6 +1162,39 @@ components:
           items:
             "$ref": "#/components/schemas/quote_check"
           description: liste des analyses de devis (QuoteChecks) dans ce dossier
+          nullable: true
+        control_codes:
+          type: array
+          items:
+            "$ref": "#/components/schemas/quote_check_error_code"
+          description: liste des codes des points contrôlés
+          nullable: true
+        controls_count:
+          type: integer
+          description: nombre de points contrôlés
+          nullable: true
+        errors:
+          type: array
+          items:
+            "$ref": "#/components/schemas/quote_check_error_code"
+          description: liste des erreurs dans ordre à afficher
+          nullable: true
+        error_details:
+          type: array
+          items:
+            "$ref": "#/components/schemas/quote_check_error_details"
+          description: liste des erreurs avec détails dans ordre à afficher
+          nullable: true
+        error_messages:
+          type: object
+          additionalProperties:
+            type: string
+            description: code d'erreur => message
+          nullable: true
+        started_at:
+          type: datetime
+        finished_at:
+          type: datetime
           nullable: true
       required:
       - id

--- a/swagger/v1/mon-devis-sans-oublis_api_v1_partner_swagger.yaml
+++ b/swagger/v1/mon-devis-sans-oublis_api_v1_partner_swagger.yaml
@@ -378,7 +378,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://www.datatourisme.fr/ontology/core/1.0/#siret
-          x-cardinality: 63252
+          x-cardinality: 63250
           x-capabilities:
             textAgg: true
           x-concept:
@@ -390,7 +390,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://www.w3.org/2000/01/rdf-schema#label
-          x-cardinality: 62619
+          x-cardinality: 62574
           x-capabilities:
             textAgg: true
           x-concept:
@@ -402,7 +402,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://schema.org/address
-          x-cardinality: 63474
+          x-cardinality: 63455
           x-capabilities:
             textAgg: true
           x-concept:
@@ -426,7 +426,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://schema.org/City
-          x-cardinality: 19541
+          x-cardinality: 19531
           x-capabilities:
             textAgg: true
           x-concept:
@@ -458,7 +458,7 @@ components:
           type: string
           description: ''
           x-refersTo: https://www.w3.org/2006/vcard/ns#tel
-          x-cardinality: 59534
+          x-cardinality: 59543
           x-capabilities:
             textAgg: true
           x-concept:
@@ -470,7 +470,7 @@ components:
           type: string
           description: ''
           x-refersTo: https://www.w3.org/2006/vcard/ns#email
-          x-cardinality: 61513
+          x-cardinality: 61591
           x-capabilities:
             textAgg: true
           x-concept:
@@ -482,7 +482,7 @@ components:
           type: string
           description: ''
           x-refersTo: https://schema.org/WebPage
-          x-cardinality: 37557
+          x-cardinality: 37598
           x-capabilities:
             textAgg: true
           x-concept:
@@ -493,14 +493,14 @@ components:
           title: Code qualification
           type: string
           description: ''
-          x-cardinality: 465
+          x-cardinality: 464
           x-capabilities:
             textAgg: true
         nom_qualification:
           title: Nom de la qualification
           type: string
           description: ''
-          x-cardinality: 473
+          x-cardinality: 472
           x-capabilities:
             textAgg: true
         url_qualification:
@@ -508,7 +508,7 @@ components:
           type: string
           description: ''
           x-refersTo: http://schema.org/DigitalDocument
-          x-cardinality: 75488
+          x-cardinality: 75492
           x-capabilities: {}
           x-concept:
             id: attachment
@@ -656,7 +656,7 @@ components:
           description: Cette date correspond à la date de début de qualification transmise
             par l'organisme de qualification
           x-capabilities: {}
-          x-cardinality: 1867
+          x-cardinality: 1869
         lien_date_fin:
           title: Date de fin de qualification
           type: string
@@ -664,7 +664,7 @@ components:
           description: Cette date correspond à la date de fin de qualification transmise
             par l'organisme de qualification
           x-capabilities: {}
-          x-cardinality: 1549
+          x-cardinality: 1551
         _file.content:
           x-calculated: true
           type: string
@@ -807,11 +807,13 @@ components:
       type: string
       enum:
       - admin
+      - case_incoherence
       - file
       - gestes
       - server
-      description: 'admin: Mentions administratives | file: Fichier | gestes: Descriptif
-        technique des gestes | server: Serveur'
+      description: 'admin: Mentions administratives | case_incoherence: Incohérence
+        des documents du dossier | file: Fichier | gestes: Descriptif technique des
+        gestes | server: Serveur'
     quote_check_error_code:
       type: string
       description: code d'erreur de validation
@@ -1198,6 +1200,8 @@ components:
             type: string
             description: code d'erreur => message
           nullable: true
+        started_at:
+          type: datetime
         finished_at:
           type: datetime
           nullable: true
@@ -1271,6 +1275,39 @@ components:
           items:
             "$ref": "#/components/schemas/quote_check"
           description: liste des analyses de devis (QuoteChecks) dans ce dossier
+          nullable: true
+        control_codes:
+          type: array
+          items:
+            "$ref": "#/components/schemas/quote_check_error_code"
+          description: liste des codes des points contrôlés
+          nullable: true
+        controls_count:
+          type: integer
+          description: nombre de points contrôlés
+          nullable: true
+        errors:
+          type: array
+          items:
+            "$ref": "#/components/schemas/quote_check_error_code"
+          description: liste des erreurs dans ordre à afficher
+          nullable: true
+        error_details:
+          type: array
+          items:
+            "$ref": "#/components/schemas/quote_check_error_details"
+          description: liste des erreurs avec détails dans ordre à afficher
+          nullable: true
+        error_messages:
+          type: object
+          additionalProperties:
+            type: string
+            description: code d'erreur => message
+          nullable: true
+        started_at:
+          type: datetime
+        finished_at:
+          type: datetime
           nullable: true
       required:
       - id


### PR DESCRIPTION
- ajout d'erreurs sur prenoms, noms et adresses incohérentes entre plusieurs documents d'un même dossier via nouvelle `category` d'erreur `case_incoherence`
- usage de la gem `fuzzy-string-match` pour la comparaison
- calculées à la volée via API QuotesCase car dépend des uploads en parallèle et asynchrone des QuoteChecks
- affichage dans Back Office du retour API `QuotesCas` avec les erreurs de cohérences éventuelles

<img width="310" alt="Screenshot 2025-06-17 at 09 26 01" src="https://github.com/user-attachments/assets/7b30503d-e02e-4e41-bc30-3242707ff472" />
