### PR TITLE
fix: QuoteFile OCR

### DIFF
--- a/app/models/concerns/quote_file_ocr.rb
+++ b/app/models/concerns/quote_file_ocr.rb
@@ -5,9 +5,9 @@ module QuoteFileOcr
   extend ActiveSupport::Concern
 
   def ocr
-    return unless ocrable?
+    return unless ocrable? || !force_ocr
 
-    @ocr ||= read_attribute(:ocr) || QuoteReader::Global::DEFAULT_OCR # TODO: save in a field
+    read_attribute(:ocr) || QuoteReader::Global::DEFAULT_OCR # TODO: save in a field
   end
 
   def ocrable?


### PR DESCRIPTION
Le champs OCR n'était pas rempli.

# Avant
<img width="284" alt="Screenshot 2025-07-08 at 09 42 42" src="https://github.com/user-attachments/assets/4eb7b0c1-270d-4d89-b8a7-34ec9e706f9b" />
