### PR TITLE
chore: disable old OCR

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,8 +1,15 @@
+# ClamAV for virus scanning
 clamav
 clamav-daemon
+
+# Rails image processing
 ghostscript
 imagemagick
-libtesseract-dev
+
+# gives pdftoppm for PDF to images
 poppler-utils
-tesseract-ocr
-tesseract-ocr-fra
+
+# tesseract
+# libtesseract-dev
+# tesseract-ocr
+# tesseract-ocr-fra

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get upgrade -y && \
         cmake pkg-config \
         libpq-dev libyaml-dev \
         nodejs npm && \
-    xargs -a /app/Aptfile apt-get install --no-install-recommends -y && \
+    grep -vE '^\s*#' /app/Aptfile | xargs -r apt-get install --no-install-recommends -y && \
         rm -rf /var/lib/apt/lists/*
 
 # 🛠️ Fix ImageMagick Security Policy for PDFs

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem "fuzzy-string-match", require: false
 gem "mime-types", require: false
 gem "mini_magick", require: false
 gem "pdf-reader", require: false
-gem "rtesseract", require: false
+# gem "rtesseract", require: false
 gem "ruby_llm", require: false
 
 # Efficiency

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -632,7 +632,6 @@ GEM
     rswag-ui (2.16.0)
       actionpack (>= 5.2, < 8.1)
       railties (>= 5.2, < 8.1)
-    rtesseract (3.1.4)
     rubocop (1.79.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -860,7 +859,6 @@ DEPENDENCIES
   rswag-api
   rswag-specs
   rswag-ui
-  rtesseract
   rubocop
   rubocop-capybara
   rubocop-factory_bot
@@ -1116,7 +1114,6 @@ CHECKSUMS
   rswag-api (2.16.0) sha256=b653f7bd92e98be18b01ab4525d88950d7b0960e293a99f856b9efcee3ae6074
   rswag-specs (2.16.0) sha256=8ba26085c408b0bd2ed21dc8015c80f417c7d34c63720ab7133c2549b5bd2a91
   rswag-ui (2.16.0) sha256=a1f49e927dceda92e6e6e7c1000f1e217ee66c565f69e28131dc98b33cd3a04f
-  rtesseract (3.1.4) sha256=7967bc726676cbfbb6923d4115d13e350cead3aab984cb0f2cbe915b78ce7e36
   rubocop (1.79.2) sha256=d3f42a7d197952c2a163719c5462fea827710a435b18bfb7070c6eedd2e90391
   rubocop-ast (1.46.0) sha256=0da7f6ad5b98614f89b74f11873c191059c823eae07d6ffd40a42a3338f2232b
   rubocop-capybara (2.22.1) sha256=ced88caef23efea53f46e098ff352f8fc1068c649606ca75cb74650970f51c0c

--- a/config/custom.rb
+++ b/config/custom.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
     QuoteReader::Image::MdsoOcrNanonets,
     QuoteReader::Image::MdsoOcrOlmOcr,
 
-    QuoteReader::Image::MistralOcr,
-    QuoteReader::Image::Tesseract
+    QuoteReader::Image::MistralOcr
+    # QuoteReader::Image::Tesseract
   ].keep_if(&:configured?).map { it.name.split("::").last }
 end

--- a/lib/quote_reader/image/tesseract.rb
+++ b/lib/quote_reader/image/tesseract.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# skip loading if gem not present
+return unless Gem.loaded_specs.key?("rtesseract")
+
 require "mini_magick"
 require "rtesseract"
 require "stringio"

--- a/spec/lib/quote_reader/image/tesseract_spec.rb
+++ b/spec/lib/quote_reader/image/tesseract_spec.rb
@@ -2,6 +2,8 @@
 
 require "rails_helper"
 
+return unless defined?(QuoteReader::Image::Tesseract)
+
 RSpec.describe QuoteReader::Image::Tesseract, type: :service do
   let(:file) { fixture_file_upload("quote_files/Devis_test.png") }
   let(:content) { file.read }


### PR DESCRIPTION
remove old stuff