### PR TITLE
fix(API): RGE SIRET error

### DIFF
--- a/app/controllers/api/v1/data_checks_controller.rb
+++ b/app/controllers/api/v1/data_checks_controller.rb
@@ -74,13 +74,15 @@ module Api
         api_user || request.headers["User-Agent"]&.to_s
       end
 
-      def extract_rge_params
+      def extract_rge_params # rubocop:disable Metrics/AbcSize
         {
           date: params[:date],
-          siret: SiretValidator.validate_format!(params[:siret]),
+          siret: params[:siret].present? ? SiretValidator.validate_format!(params[:siret]) : nil,
           rge: params[:rge].present? ? RgeValidator.validate_format!(params[:rge]) : nil,
           geste_types: Array.wrap((params[:geste_types].presence || "").split(","))
         }
+      rescue QuoteValidator::Base::ArgumentError => e
+        raise BadRequestError.new(e.message, validator_error_code: e.error_code)
       end
 
       def log_rge_request(request_params, result, _source, started_at, success:)


### PR DESCRIPTION
L'erreur sur le format du SIRET n'était pas bien formatée pour un retour propre dans l'API.

# Avant
<img width="639" height="86" alt="Screenshot 2025-09-09 at 10 23 32" src="https://github.com/user-attachments/assets/b9feaf43-4beb-4726-9268-7beceadbf9be" />

# Après
<img width="782" height="72" alt="Screenshot 2025-09-09 at 10 32 03" src="https://github.com/user-attachments/assets/040ca725-30b5-4366-86d0-2dc77a491d36" />
